### PR TITLE
Requete zoom vide

### DIFF
--- a/src/main/java/fr/ifremer/sensornanny/getdata/serverrestful/io/ObservationsSearch.java
+++ b/src/main/java/fr/ifremer/sensornanny/getdata/serverrestful/io/ObservationsSearch.java
@@ -1,5 +1,9 @@
 package fr.ifremer.sensornanny.getdata.serverrestful.io;
 
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+
 import fr.ifremer.sensornanny.getdata.serverrestful.Config;
 import fr.ifremer.sensornanny.getdata.serverrestful.constants.ObservationsFields;
 import fr.ifremer.sensornanny.getdata.serverrestful.context.CurrentUserProvider;
@@ -21,8 +25,6 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGridBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramBuilder;
 
 import java.util.concurrent.TimeUnit;
-
-import static org.elasticsearch.index.query.QueryBuilders.*;
 
 /**
  * This class allow access to elasticsearch observations databases

--- a/src/main/resources/commons-logging.properties
+++ b/src/main/resources/commons-logging.properties
@@ -1,0 +1,2 @@
+org.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog
+

--- a/src/main/resources/simplelog.properties
+++ b/src/main/resources/simplelog.properties
@@ -1,0 +1,8 @@
+# Default logging level for all instances of SimpleLog.
+# Must be either trace, debug, info, warn, error or fatal. Defaults to info.
+org.apache.commons.logging.simplelog.defaultlog=warn
+
+# Logging detail level for a SimpleLog instance named MyClassLogger.
+# Must be either trace, debug, info, warn, error or fatal. Defaults to the
+# above default if not set.
+org.apache.commons.logging.simplelog.log.fr.ifremer.sensornanny.getdata.serverrestful.io.ObservationsSearch=debug


### PR DESCRIPTION
Un bug de l'api java elasticsearch fait que le goehash calculé pour le point [90, 180] renvoie la valeur du geohash [-90,-180] ce qui fausse les requètes
On utilise maintenant directement les geopoints dans les requêtes ES
